### PR TITLE
Allow .clang-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 *~
 .idea
 examples/config.ini
-.clang-format


### PR DESCRIPTION
New logic in AliceO2Group/CodingGuidelines will sync it from a central place.