### PR TITLE
Unique values in the buffer

### DIFF
--- a/include/Monitoring/Metric.h
+++ b/include/Monitoring/Metric.h
@@ -64,6 +64,9 @@ class Metric
     /// Assign operator overload, assignes new values to the metric object
     Metric& operator=(const std::variant< int, std::string, double, uint64_t >& value);
 
+    /// Compares metric names
+    bool operator==(const Metric& rhs) const;
+
     /// Name getter
     /// \return	metric name
     const std::string& getName() const;

--- a/include/Monitoring/Monitoring.h
+++ b/include/Monitoring/Monitoring.h
@@ -86,6 +86,9 @@ class Monitoring
     /// \param size 		buffer size
     void enableBuffering(const std::size_t size = 128);
 
+    /// Same as enableBuffering, but when flushing buffer only the most recet value of given metric is sent
+    void enableUniqueBuffering(const std::size_t size = 128);
+
     /// Adds global tag
     /// \param name 		tag name
     /// \param value 		tag value
@@ -100,7 +103,6 @@ class Monitoring
     /// \param name 		metric name
     /// \return 		periodically send metric
     ComplexMetric& getAutoPushMetric(std::string name, unsigned int interval = 1);
-
   private:
     /// Sends multiple (not related to each other) metrics
     /// \param metrics  vector of metrics
@@ -140,6 +142,9 @@ class Monitoring
     /// Flag stating whether metric buffering is enabled
     bool mBuffering;
 
+    /// Unique metrics in the buffer flag
+    bool mUniqueBuffering;
+
     /// Size of buffer
     std::size_t mBufferSize;
 
@@ -151,6 +156,9 @@ class Monitoring
 
     /// Automatic metric push interval
     std::atomic<unsigned int> mAutoPushInterval;
+
+    /// Remove duplicate metrics in buffer
+    bool removeBufferDuplicates(const short index);
 };
 
 } // namespace monitoring

--- a/src/Metric.cxx
+++ b/src/Metric.cxx
@@ -94,6 +94,14 @@ Metric& Metric::operator=(const std::variant< int, std::string, double, uint64_t
   return *this;
 }
 
+bool Metric::operator==(const Metric& rhs) const
+{
+  if (getName() != rhs.getName()) {
+    return false;
+  }
+  return true;
+}
+
 Metric&& Metric::addTag(tags::Key key, tags::Value value)
 {
   mTags.push_back({static_cast<std::underlying_type<tags::Key>::type>(key), static_cast<std::underlying_type<tags::Value>::type>(value)});

--- a/test/testMonitoring.cxx
+++ b/test/testMonitoring.cxx
@@ -68,6 +68,21 @@ BOOST_AUTO_TEST_CASE(testSymbols)
   BOOST_WARN_MESSAGE(BOOST_IS_DEFINED( O2_MONITORING_OS_MAC ), "Mac OS detected");
 }
 
+BOOST_AUTO_TEST_CASE(uniqueBuffering)
+{
+  auto monitoring = Monitoring::Get("stdout://");
+  monitoring->enableUniqueBuffering(4);
+  monitoring->send({10, "myMetricIntUnique"});
+  monitoring->send({11, "myMetricInt"});
+  monitoring->send({12, "myMetricInt"});
+  monitoring->send({13, "myMetricIntAnother"});
+  monitoring->send({14, "myMetricInt"});
+  monitoring->send({15, "myMetricInt"});
+  monitoring->send({16, "myMetricInt"});
+  monitoring->send({17, "myMetricIntFlush"});
+  monitoring->send({18, "myMetricInt"});
+}
+
 } // namespace Test
 } // namespace monitoring
 } // namespace o2


### PR DESCRIPTION
@ktf If you use `enableUniqueBuffering`, during the flush duplicates will be removed. This decreases buffer size. Then, if the buffer is smaller than the value you had set, flush won't happen.