### PR TITLE
[OMON-793] Restore the kafka dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# Copyright 2019-2024 CERN and copyright holders of ALICE O2.
 # See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
@@ -76,10 +76,18 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 find_package(Boost 1.70 REQUIRED COMPONENTS unit_test_framework program_options system)
 find_package(ApMon MODULE)
 find_package(CURL MODULE)
-find_package(RdKafka CONFIG)
 find_package(InfoLogger CONFIG)
 find_package(Protobuf CONFIG)
 find_package(gRPC CONFIG)
+
+if(RDKAFKA_ROOT)
+    message("RDKAFKA_ROOT set, we enable corresponding libs and binaries")
+    find_library(RDKAFKA_LIB "rdkafka++" REQUIRED PATHS ${RDKAFKA_ROOT}/lib)
+    set(RDKAFKA_INCLUDE "${RDKAFKA_ROOT}/include")
+    set(RdKafka_FOUND true)
+else()
+    message("RDKAFKA_ROOT not set, corresponding libs and binaries won't be built")
+endif()
 
 ####################################
 # Set OUTPUT vars
@@ -142,6 +150,7 @@ target_include_directories(Monitoring
   PUBLIC
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${RDKAFKA_INCLUDE}>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
@@ -153,7 +162,7 @@ set_target_properties(Monitoring PROPERTIES OUTPUT_NAME "O2Monitoring")
 target_link_libraries(Monitoring
   PUBLIC
     Boost::boost
-    $<$<BOOL:${RdKafka_FOUND}>:RdKafka::rdkafka++>
+    $<$<BOOL:${RdKafka_FOUND}>:${RDKAFKA_LIB}>
   PRIVATE
     Boost::system
     pthread
@@ -247,8 +256,10 @@ foreach (example ${EXAMPLES})
   add_executable(${example_name} ${example})
   target_link_libraries(${example_name}
     PRIVATE
+      pthread
       Monitoring Boost::program_options
       $<$<BOOL:${CURL_FOUND}>:CURL::libcurl>
+      $<$<BOOL:${RdKafka_FOUND}>:${RDKAFKA_LIB}>
   )
 endforeach()
 
@@ -290,6 +301,7 @@ if(RdKafka_FOUND AND Protobuf_FOUND AND CURL_FOUND)
       Boost::program_options
       protobuf::libprotobuf
       $<$<BOOL:${InfoLogger_FOUND}>:AliceO2::InfoLogger>
+      $<$<BOOL:${RdKafka_FOUND}>:${RDKAFKA_LIB}>
     )
     target_compile_definitions(${example_name} PRIVATE $<$<BOOL:${InfoLogger_FOUND}>:O2_MONITORING_WITH_INFOLOGGER>)
     target_include_directories(${example_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Depends on https://github.com/alisw/alidist/pull/5712

Use the Kakfa dependency to build a number of libraries and binaries. 