### PR TITLE
Inverse logic to use smaps_rollup

### DIFF
--- a/src/ProcessMonitor.cxx
+++ b/src/ProcessMonitor.cxx
@@ -31,7 +31,7 @@ namespace o2
 namespace monitoring
 {
 
-#ifdef O2_MONITORING_OS_CS7
+#ifdef O2_MONITORING_OS_CC7
 static constexpr auto SMAPS_FILE = "/proc/self/smaps";
 #else
 static constexpr auto SMAPS_FILE = "/proc/self/smaps_rollup";

--- a/src/ProcessMonitor.cxx
+++ b/src/ProcessMonitor.cxx
@@ -31,10 +31,10 @@ namespace o2
 namespace monitoring
 {
 
-#ifdef O2_MONITORING_OS_CS8
-static constexpr auto SMAPS_FILE = "/proc/self/smaps_rollup";
-#else
+#ifdef O2_MONITORING_OS_CS7
 static constexpr auto SMAPS_FILE = "/proc/self/smaps";
+#else
+static constexpr auto SMAPS_FILE = "/proc/self/smaps_rollup";
 #endif
 
 ProcessMonitor::ProcessMonitor()


### PR DESCRIPTION

Consider not having smaps_rollup a special case, rather than the other
way around.
